### PR TITLE
Do not save a document if there's no change.

### DIFF
--- a/lib/db/collection.ts
+++ b/lib/db/collection.ts
@@ -112,6 +112,10 @@ class Collection {
 
   update(document: Document): Future<Document> {
     let updated = document.updatedValues();
+    if (_.isEmpty(updated)) {
+      return Future.successful(this.newDocument(document.doc));
+    }
+
     return this.validate(updated)
     .flatMap((updated: any) => {
       let selector = { '_id': document._id };


### PR DESCRIPTION
Not Reviewed.

In OSX, it occurs mongo error that ```MongoError: '$set' is empty. You must specify a field like so: {$mod: {<field>: ...}}```

This patch is a temporary solution for that.