### PR TITLE
Add `contains` operator to Query class.

### DIFF
--- a/lib/db/query.ts
+++ b/lib/db/query.ts
@@ -40,6 +40,10 @@ class Query {
     return new Query({ [field]: { '$nin': value } });
   }
 
+  static contains<T>(field: string, value: T[]): Query {
+    return new Query({ [field]: { '$all': value } });
+  }
+
   static where(fn: () => boolean): Query;
   static where(fn: string): Query;
   static where(fn: any): Query {
@@ -83,6 +87,10 @@ class Query {
   }
   nin<T>(field: string, value: T[]): Query {
     return Query.and(this, Query.nin(field, value));
+  }
+
+  contains<T>(field: string, value: T[]): Query {
+    return Query.and(this, Query.contains(field, value));
   }
 
   where(fn: () => boolean): Query;


### PR DESCRIPTION
A `contains` method has the same behavior of `$all` operator
that selects the documents where the value of a field
is an array that contains all the specified elements.
As there already exists `all` method and it's totally
different, I made the `contains` method that possibly has
more clear meaning.

http://docs.mongodb.org/manual/reference/operator/query/all