### PR TITLE
Add a 'headers' property in Response.

### DIFF
--- a/core/http/response.ts
+++ b/core/http/response.ts
@@ -1,16 +1,32 @@
+import _ = require('underscore');
+
 class Response {
   body: string | IResponse;
-  contentType: string;
   statusCode: number;
+  headers: IHeaders = { };
+
   constructor(body: string | IResponse, contentType?: string, statusCode?: number) {
     this.body = body;
 
-    this.contentType = contentType;
-    if (!this.contentType) {
+    if (contentType) {
+      this.contentType = contentType;
+    } else {
       this.contentType = typeof this.body === 'string' ? 'text/plain' : 'application/json';
     }
 
     this.statusCode = statusCode ? statusCode : 200;
+  }
+
+  setHeaders(object: IHeaders) {
+    this.headers = _.extend(this.headers, object);
+  }
+
+  get contentType() {
+    return this.headers['Content-Type'];
+  }
+
+  set contentType(cType: string) {
+    this.headers['Content-Type'] = cType;
   }
 }
 

--- a/core/plugin.ts
+++ b/core/plugin.ts
@@ -23,7 +23,7 @@ class Plugin implements IPlugin {
     this.handler(new Request(req))
       .onSuccess(function (result: Response) {
         res
-        .set('Content-Type', result.contentType)
+        .set(result.headers)
         .status(result.statusCode)
         .send(result.body);
       })

--- a/lib.d/beyond/beyond.d.ts
+++ b/lib.d/beyond/beyond.d.ts
@@ -10,3 +10,7 @@ interface IResponse {
   [key: string]: number | string | boolean | number[] | string[] | boolean[]
                | IResponse | IResponse[];
 }
+
+interface IHeaders {
+  [key: string]: string;
+}

--- a/test/core/response.ts
+++ b/test/core/response.ts
@@ -42,12 +42,33 @@ describe('Response', function () {
       let res = new Response('hello', 'image/jpeg');
       assert.equal(res.contentType, 'image/jpeg');
     });
+
+    it('should set the Content-Type header of a Response obj.', function () {
+      let res = new Response('hello', 'image/jpeg');
+      assert.equal(res.headers['Content-Type'], 'image/jpeg');
+    });
   });
 
   describe('#statusCode', function () {
     it('should return the status code of a Response obj.', function () {
       let res = new Response('hello', 'image/jpeg', 301);
       assert.equal(res.statusCode, 301);
+    });
+  });
+
+  describe('#headers', function () {
+    it('can be set by setHeaders() method.', function () {
+      let res = new Response('hello');
+      res.setHeaders({'Hello-Field': 'world'});
+      assert.equal(res.headers['Hello-Field'], 'world');
+    });
+
+    it('can be extended by setHeaders() method.', function () {
+      let res = new Response('hello');
+      res.setHeaders({'Hello-Field': 'world'});
+      res.setHeaders({'Hello-Field': 'world2', 'Company-Field': '100'});
+      assert.equal(res.headers['Hello-Field'], 'world2');
+      assert.equal(res.headers['Company-Field'], '100');
     });
   });
 });


### PR DESCRIPTION
The original 'contentType' property is converted to the pair of getter and setter for headers.