### PR TITLE
Call plugin's startup method after http server starting.

### DIFF
--- a/core/plugin.ts
+++ b/core/plugin.ts
@@ -14,6 +14,7 @@ let plugins: {[name: string]: Plugin} = {};
 class Plugin implements IPlugin {
   name: string;
   handler: (req: Request) => Future<Response>;
+  startup: () => void;
   private path: string;
   private collections: Collection[] = [];
 
@@ -31,6 +32,14 @@ class Plugin implements IPlugin {
       }
 
       this.collections = collections;
+    }
+
+    if (!_.isUndefined(plugin.startup)) {
+      this.startup = plugin.startup;
+    } else {
+      this.startup = () => {
+        return;
+      };
     }
   }
 
@@ -81,5 +90,11 @@ export function initialize(config: { paths: any }, db: mongodb.Db): Future<void>
   return Future.sequence(createIndices)
   .map(() => {
     return;
+  });
+}
+
+export function startup() {
+  _.map(plugins, (plugin: Plugin) => {
+    plugin.startup();
   });
 }

--- a/main.ts
+++ b/main.ts
@@ -91,6 +91,7 @@ db.initialize(appConfig.mongodb.url)
   });
 
   let server = app.listen(appConfig.port, function () {
+    plugin.startup();
     let host = server.address().address;
     let port = server.address().port;
 


### PR DESCRIPTION
If it is exist public method named 'startup' in plugin's main script,
call it after http server starting.

When the server startup, it is need a way to perform tasks that are required for plugin additionaly.
Currently, it is unable to know when the server start listening after plugin's initialization is complete.
Therefore, the server startup after its initialization is complete, call plugin's startup method if it is exist.